### PR TITLE
Type fixes

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -38,6 +38,7 @@ A quick list of the current `TODO`s.
 
 And completed items:
 
+1. **DONE** Fix type parsing code to be much simpler.
 1. **DONE** Fix (finally) the `match` form for variants/poly
 1. **DONE** Add complex types to `val`
 1. **DONE** Add complex types to records

--- a/labs/rewrite_match_bind.carml
+++ b/labs/rewrite_match_bind.carml
@@ -19,9 +19,9 @@ def make_AST tag:int lenchildren:int children:array[ref[AST]] lenvalue:int value
     set! (-> res lenchildren) lenchildren
     set! (-> res children) children
     if (<> value NULL) then
-        set! (-> res value) $ strdup value
+        (set! (-> res value) $ strdup value)
     else
-        set! (-> res value) NULL
+        (set! (-> res value) NULL)
     set! (-> res lenvalue) lenvalue
     res
 }

--- a/src/carmlc.c
+++ b/src/carmlc.c
@@ -5093,6 +5093,35 @@ llreadexpression(FILE *fdin, uint8_t nltreatment) {
             }
             return ASTRight(head);
             break;
+        case TARRAY:
+        case TREF:
+        case TDEQUET:
+        case TFUNCTIONT:
+        case TPROCEDURET:
+        case TTUPLET:
+            tmp = (AST *)hmalloc(sizeof(AST));
+            tmp->tag = ltype;
+            vectmp[idx] = tmp;
+            idx++;
+            sometmp = readexpression(fdin);
+            if(sometmp->tag == ASTLEFT) {
+                return sometmp;
+            } else if(sometmp->right->tag != TARRAYLITERAL) {
+                return ASTLeft(0, 0, "core complex types *must* have a type paramter.");
+            }
+            head = (AST *)hmalloc(sizeof(AST));
+            head->tag = TCOMPLEXTYPE;
+
+            ltmp = sometmp->right->lenchildren + 1;
+            head->lenchildren = ltmp;
+            head->children = (AST **)hmalloc(sizeof(AST *) * ltmp);
+            head->children[0] = vectmp[idx - 1];
+            // XXX: is this needed?
+            for(int cidx = 1, tidx = 0; tidx < (ltmp - 1); cidx++, tidx++) {
+                head->children[cidx] = sometmp->right->children[tidx];
+            }
+            head = linearize_complex_type(head);
+            return ASTRight(head);
         case THEX:
         case TOCT:
         case TBIN:
@@ -5101,12 +5130,7 @@ llreadexpression(FILE *fdin, uint8_t nltreatment) {
         case TSTRING:
         case TCHAR:
         case TBOOL:
-        case TARRAY:
-        case TDEQUET:
-		case TPROCEDURET:
-		case TFUNCTIONT:
         case TCOMMA:
-        case TTUPLET:
         case TANY:
         case TAND:
         case TFALSE:
@@ -5121,7 +5145,6 @@ llreadexpression(FILE *fdin, uint8_t nltreatment) {
         case TSEMI:
         case TFATARROW:
         case TPIPEARROW:
-        case TREF:
         case TGIVEN:
             head = (AST *)hmalloc(sizeof(AST));
             head->tag = ltype;

--- a/src/carmlc.c
+++ b/src/carmlc.c
@@ -416,6 +416,7 @@ istypeast(int tag) {
         case TTUPLET:
         case TFUNCTIONT:
         case TPROCEDURET:
+        case TCOMPLEXTYPE:
         case TSTRT:
         case TTAG: // user types 
         case TBOOLT:
@@ -4682,31 +4683,8 @@ llreadexpression(FILE *fdin, uint8_t nltreatment) {
             } else { // complex type
                 tmp = sometmp->right;
                 switch(tmp->tag) {
-                    case TARRAY:
-                    case TREF:
-                    case TDEQUET:
-                    case TFUNCTIONT:
-                    case TPROCEDURET:
-                    case TTUPLET:
-                        vectmp[idx] = tmp;
-                        idx++;
-                        sometmp = readexpression(fdin);
-                        if(sometmp->tag == ASTLEFT) {
-                            return sometmp;
-                        } else if(sometmp->right->tag != TARRAYLITERAL) {
-                            return ASTLeft(0, 0, "core complex types *must* have a type paramter.");
-                        }
-                        tmp = (AST *)hmalloc(sizeof(AST));
-                        tmp->tag = TCOMPLEXTYPE;
-
-                        ltmp = sometmp->right->lenchildren + 1;
-                        tmp->lenchildren = ltmp;
-                        tmp->children = (AST **)hmalloc(sizeof(AST *) * ltmp);
-                        tmp->children[0] = vectmp[idx - 1];
-                        for(int cidx = 1, tidx = 0; tidx < (ltmp - 1); cidx++, tidx++) {
-                            tmp->children[cidx] = sometmp->right->children[tidx];
-                        }
-                        head->children[0] = linearize_complex_type(tmp);
+                    case TCOMPLEXTYPE:
+                        head->children[0] = tmp;
                         break;
                     case TTAG:
                     default:

--- a/src/carmlc.c
+++ b/src/carmlc.c
@@ -4811,8 +4811,10 @@ llreadexpression(FILE *fdin, uint8_t nltreatment) {
                         } else if(sometmp->right->tag == TNEWL || sometmp->right->tag == TSEMI) {
                             1;
                         } else if(sometmp->right->tag == TARRAYLITERAL) {
-                            vectmp[idx] = sometmp->right;
-                            idx++;
+                            tmp = sometmp->right;
+                            for(int tidx = 0; tidx < tmp->lenchildren; tidx++, idx++) {
+                                vectmp[idx] = tmp->children[tidx];
+                            }
                         } else {
                             return ASTLeft(0, 0, "a complex user type must be followed by either an array literal of types or a newline/semi-colon");
                         }

--- a/src/carmlc.c
+++ b/src/carmlc.c
@@ -4755,83 +4755,51 @@ llreadexpression(FILE *fdin, uint8_t nltreatment) {
                 } else if(issimpletypeast(sometmp->right->tag)) {
                     head->children[1] = sometmp->right;
                 } else {
-                    /* complex type...
-                     */
-                    flag = idx;
-                    /* we hit a complex type,
-                     * now we're looking for 
-                     * either `of` or `=`.
-                     */
-                    vectmp[idx++] = sometmp->right;
-                    typestate = 1; 
-                    while(sometmp->right->tag != TEQ) {
-                        sometmp = readexpression(fdin);
-
-                        if(sometmp->right->tag == ASTLEFT) {
-                            return sometmp;
-                        }
-
-                        switch(typestate) {
-                            case 0: // awaiting a type
-                                if(!istypeast(sometmp->right->tag)) {
-                                    return ASTLeft(0, 0, "expected type in `:` form");
-                                } else if(issimpletypeast(sometmp->right->tag)) {
-                                    typestate = 2;
-                                } else {
-                                    typestate = 1;
-                                }
-
-                                vectmp[idx++] = sometmp->right;
-                                break;
-                            case 1: // awaiting either TOF or an end
-                                if(sometmp->right->tag == TOF) {
-                                    typestate = 0;
-                                } else if(sometmp->right->tag == TEQ) {
-                                    typestate = 3;
-                                } else if(sometmp->right->tag == TARRAYLITERAL) {
-                                    tmp = sometmp->right;
-                                    for(int cidx = 0; cidx < tmp->lenchildren; cidx++) {
-                                        vectmp[idx++] = tmp->children[cidx];
-                                    }
-                                    typestate = 2;
-                                } else {
-                                    return ASTLeft(0, 0, "expected either an `of` or a `=`");
-                                }
-                                break;
-                            case 2:
-                            case 3:
-                                break;
-                        }
-                        if(typestate == 2 || typestate == 3) {
+                    tmp = sometmp->right;
+                    switch(tmp->tag) {
+                        case TCOMPLEXTYPE:
+                            head->children[1] = tmp;
+                            sometmp = readexpression(fdin);
+                            if(sometmp->tag == ASTLEFT) {
+                                return sometmp;
+                            } else if(sometmp->right->tag != TEQ) {
+                                return ASTLeft(0, 0, "a `val` type definition *must* be followed by an `=`...");
+                            }
                             break;
-                        }
+                        case TTAG:
+                        default:
+                            vectmp[idx] = tmp;
+                            idx++;
+                            sometmp = llreadexpression(fdin, YES);
+                            if(sometmp->tag == ASTLEFT) {
+                                return sometmp;
+                            } else if(sometmp->right->tag == TEQ) {
+                                tmp->children = (AST **)hmalloc(sizeof(AST *));
+                                tmp->lenchildren = 1;
+                                head->children[1] = tmp;
+                            } else if(sometmp->right->tag != TARRAYLITERAL) {
+                                return ASTLeft(0, 0, "tagged user data types *must* be followed by an array literal or a terminator (newline or semicolon)");
+                            } else {
+                                tmp = (AST *)hmalloc(sizeof(AST));
+                                tmp->tag = TCOMPLEXTYPE;
+                                ltmp = sometmp->right->lenchildren + 1;
+                                tmp->children = (AST **)hmalloc(sizeof(AST *) * ltmp);
+                                tmp->lenchildren = ltmp;
+                                tmp->children[0] = vectmp[idx - 1];
+                                for(int cidx = 1; cidx < ltmp; cidx++) {
+                                    tmp->children[cidx] = sometmp->right->children[cidx - 1];
+                                }
+                                head->children[1] = linearize_complex_type(tmp);
+                                sometmp = readexpression(fdin);
+                                if(sometmp->tag == ASTLEFT) {
+                                    return sometmp;
+                                } else if(sometmp->right->tag != TEQ) {
+                                    return ASTLeft(0, 0, "a `val` type definition *must* be followed by an `=`...");
+                                }
+                            }
+                            break;
                     }
-                    /* collapse the above type states here... */
-                    tmp = (AST *) hmalloc(sizeof(AST));
-                    tmp->tag = TCOMPLEXTYPE;
-                    tmp->lenchildren = idx - flag;
-                    tmp->children = (AST **) hmalloc(sizeof(AST *) * tmp->lenchildren);
-                    for(int cidx = 0, tidx = flag, tlen = tmp->lenchildren; cidx < tlen; cidx++, tidx++) {
-                        tmp->children[cidx] = vectmp[tidx];
-                    }
-                    tmp = linearize_complex_type(tmp);
-                    vectmp[flag] = tmp;
-                    idx = flag;
-                    flag = 0;
-                    head->children[1] = tmp;
                 }
-               
-                if(typestate != 3) {
-
-                    sometmp = readexpression(fdin);
-
-                    if(sometmp->tag == ASTLEFT) {
-                        return sometmp;
-                    } else if(sometmp->right->tag != TEQ) {
-                        return ASTLeft(0, 0, "a `val` type definition *must* be followed by an `=`...");
-                    }
-                }
-
             } else {
                 head->lenchildren = 1;
                 head->children = (AST **)hmalloc(sizeof(AST *));

--- a/src/carmlc.c
+++ b/src/carmlc.c
@@ -4458,7 +4458,7 @@ llreadexpression(FILE *fdin, uint8_t nltreatment) {
                     case 0:
                         if(sometmp->right->tag == TIDENT) {
                             typestate = 1;
-                        } else if(issimpletypeast(sometmp->right->tag)) {
+                        } else if(issimpletypeast(sometmp->right->tag) || sometmp->right->tag == TCOMPLEXTYPE) {
                             typestate = 0;
                         } else if(iscomplextypeast(sometmp->right->tag)) {
                             flag = idx; // start of complex type
@@ -4499,65 +4499,16 @@ llreadexpression(FILE *fdin, uint8_t nltreatment) {
                         break;
                     case 3:
                         debugln;
-                        if(sometmp->right->tag == TOF) {
-                            debugln;
-                            typestate = 4;
-                        } else if(sometmp->right->tag == TIDENT) {
-                            debugln;
-                            typestate = 1;
-                        } else if(issimpletypeast(sometmp->right->tag)) {
-                            debugln;
-                            typestate = 0;
-                        } else if(iscomplextypeast(sometmp->right->tag)) {
-                            debugln;
-                            typestate = 3;
-                        } else if(sometmp->right->tag == TARRAYLITERAL) {
-                            debugln;
-                            typestate = 0;
-                            tmp = sometmp->right;
-                            for(int tidx = 0; tidx < tmp->lenchildren; tidx++, idx++) {
-                                debugln;
-                                vectmp[idx] = tmp->children[tidx];
-                            }
-                            debugln;
-                        } else if(sometmp->right->tag == TEND || sometmp->right->tag == TNEWL || sometmp->right->tag == TSEMI) {
-                            debugln;
-                            typestate = -1;
-                        }
-
-                        debugln;
-
-                        if(typestate != 4 && typestate != -1) {
-                            debugln;
-                            dprintf("typestate == %d\n", typestate);
-                            tmp = (AST *)hmalloc(sizeof(AST));
-                            tmp->tag = TCOMPLEXTYPE;
-                            tmp->lenchildren = idx - flag;
-                            tmp->children = (AST **)hmalloc(sizeof(AST *) * tmp->lenchildren);
-                            for(int cidx = 0, tidx = flag, tlen = tmp->lenchildren; cidx < tlen; cidx++, tidx++) {
-                                tmp->children[cidx] = vectmp[tidx];
-                            }
-                            vectmp[flag] = tmp;
-                            flag = flag + 1;
-                            idx = flag;
-                            //flag = 0;
-                            /*nstack[nsp] = tmp;
-                            nsp++;
-                            collapse_complex = 0;*/
-                            // this is *very* gross
-                            if(typestate == 3 || (typestate == 0 && sometmp->right->tag != TARRAYLITERAL)) {
-                                vectmp[idx] = sometmp->right;
-                                idx++;
-                            }
-                        }
-                        break;
-                    case 4:
                         if(sometmp->right->tag == TIDENT) {
                             debugln;
                             typestate = 1;
-                        } else if(issimpletypeast(sometmp->right->tag)) {
+                            vectmp[idx] = sometmp->right;
+                            idx++;
+                        } else if(issimpletypeast(sometmp->right->tag) || sometmp->right->tag == TCOMPLEXTYPE) {
                             debugln;
                             typestate = 0;
+                            vectmp[idx] = sometmp->right;
+                            idx++;
                         } else if(iscomplextypeast(sometmp->right->tag)) {
                             debugln;
                             typestate = 3;
@@ -4567,40 +4518,26 @@ llreadexpression(FILE *fdin, uint8_t nltreatment) {
                             debugln;
                             typestate = 0;
                             tmp = sometmp->right;
-                            for(int tidx = 0; tidx < tmp->lenchildren; tidx++, idx++) {
+                            ctmp = (AST *)hmalloc(sizeof(AST));
+                            ctmp->tag = TCOMPLEXTYPE;
+                            ctmp->lenchildren = 1 + tmp->lenchildren;
+                            ctmp->children = (AST **)hmalloc(sizeof(AST *) * ctmp->lenchildren);
+                            ctmp->children[0] = vectmp[flag];
+                            for(int tidx = 0, cidx = 1; cidx < ctmp->lenchildren; tidx++, cidx++) {
                                 debugln;
-                                vectmp[idx] = tmp->children[tidx];
+                                ctmp->children[cidx] = tmp->children[tidx];
                             }
+                            vectmp[flag] = ctmp;
+                            idx = flag + 1;
+                            flag = -1;
                             debugln;
                         } else if(sometmp->right->tag == TEND || sometmp->right->tag == TNEWL || sometmp->right->tag == TSEMI) {
                             debugln;
                             typestate = -1;
                         }
 
-                        if(typestate != 3 && typestate != -1) {
-                            debugln;
-                            dprintf("typestate == %d\n", typestate);
-                            tmp = (AST *)hmalloc(sizeof(AST));
-                            tmp->tag = TCOMPLEXTYPE;
-                            tmp->lenchildren = idx - flag;
-                            tmp->children = (AST **)hmalloc(sizeof(AST *) * tmp->lenchildren);
-                            for(int cidx = 0, tidx = flag, tlen = tmp->lenchildren; cidx < tlen; cidx++, tidx++) {
-                                tmp->children[cidx] = vectmp[tidx];
-                            }
-                            vectmp[flag] = tmp;
-                            flag = flag + 1;
-                            idx = flag;
-                            //flag = 0;
-                            /*nstack[nsp] = tmp;
-                            nsp++;
-                            collapse_complex = 0;*/
-                            //vectmp[idx] = sometmp->right;
-                            //idx++;
-                        }
+                        debugln;
                         break;
-                }
-
-                if(collapse_complex) {
                 }
 
                 // ok, we got to the end of *something*


### PR DESCRIPTION
This PR pares down the type parsing code across:

- `extern`
- `let` and `letrec`
- `val` and `var`
- parameters
- variants (and polymorphic variants)
- records

There is probably a *lot* more simplification that can go on here, but now at least simple type parsing is handled by items such as `array` and `tuple` knowing they must be accompanied by a type. This change is partially required because originally I was thinking that `array` could be written on it's own, but that syntax has been removed in favor of `array[Any]`, which I think is more explicit, and means we can cut down a lot of the type parsing code.